### PR TITLE
Fix the invert and reverse flags so they invoke the correct actions

### DIFF
--- a/nandtool/nand.py
+++ b/nandtool/nand.py
@@ -116,8 +116,8 @@ class NAND:
     def bch_correct_chunk(self, data, ecc):
         uncorrectable = False
         # modify data and ecc buffers if needed
-        ecc = modify_buffer(ecc, self.layout.ecc_invert, self.layout.ecc_reverse)
-        data = modify_buffer(data, self.layout.data_invert, self.layout.data_reverse)
+        ecc = modify_buffer(ecc, self.layout.ecc_reverse, self.layout.ecc_invert)
+        data = modify_buffer(data, self.layout.data_reverse, self.layout.data_invert)
         if self.layout.left_shift == 4:
             ecc = bytes.fromhex(ecc.hex()[1:] + "0")
 
@@ -139,8 +139,8 @@ class NAND:
         # modify data and ecc buffers to revert back
         if self.layout.left_shift == 4:
             ecc = bytes.fromhex("0" + ecc.hex()[:-1])
-        ecc = modify_buffer(ecc, self.layout.ecc_invert, self.layout.ecc_reverse)
-        data = modify_buffer(data, self.layout.data_invert, self.layout.data_reverse)
+        ecc = modify_buffer(ecc, self.layout.ecc_reverse, self.layout.ecc_invert)
+        data = modify_buffer(data, self.layout.data_reverse, self.layout.data_invert)
 
         return data, ecc, uncorrectable
 

--- a/nandtool/nand.py
+++ b/nandtool/nand.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 LOGGER = logging.getLogger(__name__)
 
 
-def modify_buffer(buffer, reverse=False, invert=False, left_shift=False):
+def modify_buffer(buffer, invert=False, reverse=False, left_shift=False):
     if not buffer:
         return None
 
@@ -116,8 +116,8 @@ class NAND:
     def bch_correct_chunk(self, data, ecc):
         uncorrectable = False
         # modify data and ecc buffers if needed
-        ecc = modify_buffer(ecc, self.layout.ecc_reverse, self.layout.ecc_invert)
-        data = modify_buffer(data, self.layout.data_reverse, self.layout.data_invert)
+        ecc = modify_buffer(ecc, self.layout.ecc_invert, self.layout.ecc_reverse)
+        data = modify_buffer(data, self.layout.data_invert, self.layout.data_reverse)
         if self.layout.left_shift == 4:
             ecc = bytes.fromhex(ecc.hex()[1:] + "0")
 
@@ -139,8 +139,8 @@ class NAND:
         # modify data and ecc buffers to revert back
         if self.layout.left_shift == 4:
             ecc = bytes.fromhex("0" + ecc.hex()[:-1])
-        ecc = modify_buffer(ecc, self.layout.ecc_reverse, self.layout.ecc_invert)
-        data = modify_buffer(data, self.layout.data_reverse, self.layout.data_invert)
+        ecc = modify_buffer(ecc, self.layout.ecc_invert, self.layout.ecc_reverse)
+        data = modify_buffer(data, self.layout.data_invert, self.layout.data_reverse)
 
         return data, ecc, uncorrectable
 


### PR DESCRIPTION
I found that the `ecc_protected_data_invert` and `ecc_invert` flags worked inconsistently: they actually _reversed_ bits of the input.

It might be something easy to fix... Please check the proposed change.

(Now I'm wondering why the test was passing at all... Oh, I see! They are being called by name for these particular cases.)